### PR TITLE
added additional carriage return

### DIFF
--- a/R/import-from.R
+++ b/R/import-from.R
@@ -37,7 +37,7 @@ import_from <- function(fun, quiet = FALSE) {
   body_ <- paste(body_, collapse = "\n")
   res <- generate_import_from(body_)
   if (!quiet)
-    cat(paste(res, collapse = "\n"))
+    cat(paste0(paste(res, collapse = "\n"),"\n"))
   invisible(paste(res, collapse = "\n"))
 }
 


### PR DESCRIPTION
I found that when warnings or messages are printed after the output of `import_from()` the messages are concatenated to the last `importFrom` line. For example,

```r
> for(f in c(shinyWidgets::dropdownButton,shinyWidgets::prettySwitch)) {
+   import_from(f)
+ }
#' @importFrom htmltools validateCssUnit tags#' @importFrom htmltools validateCssUnit
#' @importFrom shiny restoreInput

> import_from2 <- function(f) {
+   import_from(f)
+   message("importFrom complete!")
+ }
> import_from2(shinyWidgets::dropdownButton)
#' @importFrom htmltools validateCssUnit tagsimportFrom complete!
```

Adding an additional carriage return forces subsequent output to the next line.

```r
> for(f in c(shinyWidgets::dropdownButton,shinyWidgets::prettySwitch)) {
+   import_from(f)
+ }
#' @importFrom htmltools validateCssUnit tags
#' @importFrom htmltools validateCssUnit
#' @importFrom shiny restoreInput
> import_from2 <- function(f) {
+   import_from(f)
+   message("importFrom complete!")
+ }
> import_from2(shinyWidgets::dropdownButton)
#' @importFrom htmltools validateCssUnit tags
importFrom complete!
```