### PR TITLE
fix(check_import_from.R): edge case of a packge not importing functions

### DIFF
--- a/R/check_import_from.R
+++ b/R/check_import_from.R
@@ -1,34 +1,34 @@
 
 #' @title Check \code{importFrom} in \code{NAMESPACE}
-#' 
-#' @description Checks if the functions declared in the NAMESPACE 
+#'
+#' @description Checks if the functions declared in the NAMESPACE
 #' importFrom are actually used in the package functions.
-#' 
+#'
 #' @param path Path to package directory.
 #'
 #' @return Functions not used invisibly.
 #' @export
-#' 
+#'
 #' @importFrom stringi stri_subset stri_split_regex stri_subset_regex stri_detect_fixed stri_c
 #'
 #' @examples
 #' \dontrun{
-#' 
+#'
 #' # Execute in a package directory
 #' check_import_from()
-#' 
+#'
 #' }
 check_import_from <- function(path = ".") {
   if (!file.exists(file.path(path, "NAMESPACE")))
     stop("No NAMESPACE to check.", call. = FALSE)
-  
+
   # search funs in importFrom
   namespace <- readLines(con = file.path(path, "NAMESPACE"), warn = FALSE)
   importFrom <- stri_subset(str = namespace, regex = "^importFrom")
   importFrom <- stri_split_regex(str = importFrom, pattern = "\\(|,|\\)")
   importFrom <- lapply(importFrom, `[`, 3)
   importFrom <- unlist(importFrom)
-  
+
   # Read all R scripts
   r_scripts <- list.files(path = file.path(path, "R"), pattern = "(R|r)$")
   r_scripts <- lapply(
@@ -37,7 +37,7 @@ check_import_from <- function(path = ".") {
   )
   r_scripts <- unlist(r_scripts)
   r_scripts <- stri_subset_regex(str = r_scripts, pattern = "^#", negate = TRUE)
-  
+
   # Check if funs appears
   appears <- lapply(
     X = importFrom,
@@ -45,7 +45,7 @@ check_import_from <- function(path = ".") {
       any(stri_detect_fixed(str = r_scripts, pattern = x))
     }
   )
-  appears <- unlist(appears)
+  appears <- as.logical(appears)
   appears <- importFrom[!appears]
   if (length(appears) == 0) {
     message("All functions in @importFrom are used !")
@@ -55,4 +55,3 @@ check_import_from <- function(path = ".") {
     return(invisible(appears))
   }
 }
-


### PR DESCRIPTION
* fixed a bug where a package didn't import any functions via importFrom, which led to an uninformative error
* now uses a different way to cast the list to an array, which avoids creating the offending NULL value

Closes #7